### PR TITLE
Trello 7 u39ec i7 update tasks after user mapping

### DIFF
--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
@@ -31,12 +31,11 @@ class IntegrationAssetService(
     private val streamBridge: StreamBridge,
     private val amqpConfigs: AmqpConfigurations,
 ) {
-    fun findForSourceSyncId(
-        sourceSyncId: String,
-    ) = repository.findUsingFilter(
-        ListIntegrationAssetFilter(null, null, listOf(sourceSyncId)),
-        allowAnonymous = true, // assets dont have information about admin
-    )
+    fun findForSourceSyncId(sourceSyncId: String) =
+        repository.findUsingFilter(
+            ListIntegrationAssetFilter(null, null, listOf(sourceSyncId)),
+            allowAnonymous = true, // assets dont have information about admin
+        )
 
     /**
      * Method to modify [SourceSync].
@@ -60,14 +59,12 @@ class IntegrationAssetService(
                     allowAnonymous = true, // assets dont have information about admin
                 ).toList()
         val updatedAssets = mutableListOf<IntegrationAsset>()
-        val pendingUpdatedAssets =
-            mutableListOf<IntegrationAsset>() // unsynced assets
+        val pendingUpdatedAssets = mutableListOf<IntegrationAsset>() // unsynced assets
 
         assets.forEach { asset ->
             val existing =
                 existingSourceSyncAssets.find { existing ->
-                    existing.sourceData.id ==
-                        asset.sourceData.id
+                    existing.sourceData.id == asset.sourceData.id
                 }
             updatedAssetOrNull(asset, existing)?.let {
                 if (existing == null || existing.integrationAssetStatus.isSynced()) {

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
@@ -1,7 +1,6 @@
 package com.angorasix.projects.management.integrations.application
 
 import com.angorasix.commons.domain.DetailedContributor
-import com.angorasix.commons.domain.SimpleContributor
 import com.angorasix.commons.infrastructure.intercommunication.dto.A6DomainResource
 import com.angorasix.commons.infrastructure.intercommunication.dto.A6InfraTopics
 import com.angorasix.commons.infrastructure.intercommunication.dto.domainresources.A6InfraBulkResourceDto
@@ -110,7 +109,7 @@ class IntegrationAssetService(
     }
 
     suspend fun syncAssetsToTasks(
-        persistedAssets: List<IntegrationAsset>,
+        assets: List<IntegrationAsset>,
         projectManagementId: String,
         sourceSyncId: String,
         syncingEventId: String,
@@ -118,7 +117,7 @@ class IntegrationAssetService(
         mappings: SourceSyncMappings
     ) {
         publishUpdatedAssets(
-            persistedAssets,
+            assets,
             amqpConfigs.bindings.mgmtIntegrationSyncing,
             projectManagementId,
             "$sourceSyncId:$syncingEventId",
@@ -126,7 +125,7 @@ class IntegrationAssetService(
             mappings,
         )
         repository.registerEvent(
-            ListIntegrationAssetFilter(persistedAssets.mapNotNull { it.id }),
+            ListIntegrationAssetFilter(assets.mapNotNull { it.id }),
             IntegrationAssetSyncEvent.syncing(syncingEventId),
         )
     }

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/IntegrationAssetService.kt
@@ -82,9 +82,7 @@ class IntegrationAssetService(
         publishUpdatedAssets(
             persistedAssets,
             amqpConfigs.bindings.mgmtIntegrationSyncing,
-            projectManagementId,
-            sourceSyncId,
-            requestingContributor,
+            AssetsContext(projectManagementId, sourceSyncId, requestingContributor),
             mappings,
         )
         repository.registerEvent(
@@ -96,9 +94,7 @@ class IntegrationAssetService(
         publishUpdatedAssets(
             pendingUpdatedAssets,
             amqpConfigs.bindings.pendingSyncingOut,
-            projectManagementId,
-            sourceSyncId,
-            requestingContributor,
+            AssetsContext(projectManagementId, sourceSyncId, requestingContributor),
             mappings,
         )
         repository.registerEvent(
@@ -120,9 +116,7 @@ class IntegrationAssetService(
         publishUpdatedAssets(
             assets,
             amqpConfigs.bindings.mgmtIntegrationSyncing,
-            projectManagementId,
-            sourceSyncId,
-            requestingContributor,
+            AssetsContext(projectManagementId, sourceSyncId, requestingContributor),
             mappings,
         )
         repository.registerEvent(
@@ -146,9 +140,7 @@ class IntegrationAssetService(
     private fun publishUpdatedAssets(
         updatedAssets: List<IntegrationAsset>,
         bindingKey: String,
-        projectManagementId: String,
-        sourceSyncId: String,
-        requestingContributor: DetailedContributor,
+        assetsContext: AssetsContext,
         mappings: Map<String, String?>,
     ) {
         if (updatedAssets.isNotEmpty()) {
@@ -162,12 +154,12 @@ class IntegrationAssetService(
                 MessageBuilder
                     .withPayload(
                         A6InfraMessageDto(
-                            projectManagementId,
+                            assetsContext.projectManagementId,
                             A6DomainResource.ProjectManagement,
-                            sourceSyncId,
+                            assetsContext.sourceSyncId,
                             A6DomainResource.IntegrationSourceSync.value,
                             A6InfraTopics.TASKS_INTEGRATION_FULL_SYNCING.value,
-                            requestingContributor,
+                            assetsContext.requestingContributor,
                             messageData.toMap(),
                         ),
                     ).build(),
@@ -175,6 +167,12 @@ class IntegrationAssetService(
         }
     }
 }
+
+data class AssetsContext(
+    val projectManagementId: String,
+    val sourceSyncId: String,
+    val requestingContributor: DetailedContributor,
+)
 
 private fun updatedAssetOrNull(
     asset: IntegrationAsset,

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/SourceSyncService.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/SourceSyncService.kt
@@ -168,10 +168,10 @@ class SourceSyncService(
             }
 
         SourceSyncOperation.REPLACE_MAPPING_USERS_DATA ->
-            resendAssets(patchedSourceSync, requestingContributor)
+            syncAssets(patchedSourceSync, requestingContributor)
     }
 
-    private suspend fun resendAssets(patchedSourceSync: SourceSync, requestingContributor: DetailedContributor) : SourceSync {
+    private suspend fun syncAssets(patchedSourceSync: SourceSync, requestingContributor: DetailedContributor) : SourceSync {
         requireNotNull(patchedSourceSync.id) { "SourceSync id required for resendAssets" }
         val syncingEventId = UUID.randomUUID().toString()
         val assets = assetsService.findForSourceSyncId(patchedSourceSync.id).toList()

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/SourceSyncService.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/SourceSyncService.kt
@@ -172,18 +172,16 @@ class SourceSyncService(
     }
 
     private suspend fun syncAssets(patchedSourceSync: SourceSync, requestingContributor: DetailedContributor) : SourceSync {
-        requireNotNull(patchedSourceSync.id) { "SourceSync id required for resendAssets" }
-        val syncingEventId = UUID.randomUUID().toString()
+        requireNotNull(patchedSourceSync.id) { "SourceSync id required for syncAssets" }
         val assets = assetsService.findForSourceSyncId(patchedSourceSync.id).toList()
-        assetsService.syncAssetsToTasks(
-            assets,
-            patchedSourceSync.projectManagementId,
-            patchedSourceSync.id,
-            syncingEventId,
-            requestingContributor,
-            patchedSourceSync.mappings,
-        )
 
+        assetsService.syncAssets(
+            assets,
+            patchedSourceSync.id,
+            patchedSourceSync.projectManagementId,
+            requestingContributor,
+            patchedSourceSync.mappings.users,
+        )
         return patchedSourceSync
     }
 
@@ -206,7 +204,7 @@ class SourceSyncService(
                 patchedSourceSync.id,
                 patchedSourceSync.projectManagementId,
                 requestingContributor,
-                patchedSourceSync.mappings,
+                patchedSourceSync.mappings.users,
             )
 
         patchedSourceSync.addEvent(

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/application/strategies/source/TrelloSourceSyncStrategy.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/application/strategies/source/TrelloSourceSyncStrategy.kt
@@ -224,7 +224,7 @@ class TrelloSourceSyncStrategy(
                                 title = it.name,
                                 description = it.desc,
                                 dueInstant = parseDueDate(it.due),
-                                assigneeIds = emptyList(),
+                                assigneeIds = it.idMembers ?: emptyList(),
                                 done = it.dueComplete == true,
                                 estimations = extractEstimationData(it, trelloPluginId),
                             ),

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
@@ -2,10 +2,8 @@ package com.angorasix.projects.management.integrations.domain.integration.source
 
 import com.angorasix.commons.domain.SimpleContributor
 import com.angorasix.commons.domain.inputs.InlineFieldSpec
-import com.angorasix.projects.management.integrations.domain.integration.asset.IntegrationAsset
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.PersistenceCreator
-import org.springframework.data.annotation.Transient
 import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.Instant
@@ -36,9 +34,6 @@ data class SourceSync
         val events: MutableList<SourceSyncEvent> = mutableListOf(),
         val mappings: SourceSyncMappings = SourceSyncMappings(),
     ) {
-        @Transient
-        var assets: List<IntegrationAsset> = emptyList()
-
         /**
          * Checks whether a particular contributor is Admin of this Club.
          *
@@ -146,7 +141,7 @@ enum class SourceSyncEventValues {
     REQUEST_FULL_SYNC,
     TRIGGERED_FULL_SYNC,
     REQUEST_UPDATE_SYNC_CONFIG,
-    FULL_SYNC_CORRESPONDENCE,
+    SYNC_CORRESPONDENCE,
     STARTING_MEMBER_MATCH,
 }
 

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
@@ -191,6 +191,10 @@ data class SourceSyncMappings(
     fun addNewUserMappings(newUserMappings: Map<String, String?>) {
         users.putAllIfAbsent(newUserMappings)
     }
+
+    fun getContributorsFromSources(sources: List<String>):Set<String> {
+        return users.filterValues { sources.contains(it) }.keys
+    }
 }
 
 private fun <K, V> MutableMap<K, V>.putAllIfAbsent(other: Map<K, V>) {

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/domain/integration/sourcesync/SourceSync.kt
@@ -47,8 +47,7 @@ data class SourceSync
         fun isAdmin(contributorId: String?): Boolean =
             (contributorId != null).and(
                 admins.any {
-                    it.contributorId ==
-                        contributorId
+                    it.contributorId == contributorId
                 },
             )
 
@@ -67,17 +66,11 @@ data class SourceSync
             config.steps.add(step)
         }
 
-        fun wasRequestedFullSync(): Boolean =
-            isActive() &&
-                events.last().type == SourceSyncEventValues.REQUEST_FULL_SYNC
+        fun wasRequestedFullSync(): Boolean = isActive() && events.last().type == SourceSyncEventValues.REQUEST_FULL_SYNC
 
-        fun wasRequestedDisable(): Boolean =
-            isDisabled() &&
-                events.last().type == SourceSyncEventValues.REQUEST_UPDATE_STATE
+        fun wasRequestedDisable(): Boolean = isDisabled() && events.last().type == SourceSyncEventValues.REQUEST_UPDATE_STATE
 
-        fun requiresFurtherConfiguration(): Boolean =
-            isInProgress() &&
-                config.steps.any { !it.isCompleted() }
+        fun requiresFurtherConfiguration(): Boolean = isInProgress() && config.steps.any { !it.isCompleted() }
 
         companion object {
             fun initiate(
@@ -135,8 +128,7 @@ enum class SourceSyncStatusValues {
 data class SourceSyncConfig(
     var accessToken: String? = null,
     var sourceUserId: String? = null,
-    val steps: MutableList<SourceSyncStatusStep> =
-        mutableListOf(),
+    val steps: MutableList<SourceSyncStatusStep> = mutableListOf(),
 //        arrayListOf(),
 )
 
@@ -192,9 +184,7 @@ data class SourceSyncMappings(
         users.putAllIfAbsent(newUserMappings)
     }
 
-    fun getContributorsFromSources(sources: List<String>):Set<String> {
-        return users.filterValues { sources.contains(it) }.keys
-    }
+    fun getContributorsFromSources(sources: List<String>): Set<String> = users.filterValues { sources.contains(it) }.keys
 }
 
 private fun <K, V> MutableMap<K, V>.putAllIfAbsent(other: Map<K, V>) {

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/domain/SourceSyncContext.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/domain/SourceSyncContext.kt
@@ -1,0 +1,40 @@
+package com.angorasix.projects.management.integrations.infrastructure.domain
+
+import com.angorasix.commons.domain.SimpleContributor
+import com.angorasix.projects.management.integrations.domain.integration.sourcesync.SourceSync
+
+class SourceSyncContext private constructor(
+    val sourceSyncId: String,
+    val projectManagementId: String,
+    private val admins: Set<SimpleContributor>,
+    val configurations: SourceSyncContextConfigurations,
+) {
+    fun requireAdmin(contributorId: String?) {
+        if (!isAdmin(contributorId)) {
+            throw IllegalArgumentException("Contributor is not a SourceSync admin")
+        }
+    }
+
+    private fun isAdmin(contributorId: String?): Boolean =
+        (contributorId != null).and(
+            admins.any {
+                it.contributorId == contributorId
+            },
+        )
+
+    companion object {
+        fun SourceSync.context(): SourceSyncContext =
+            SourceSyncContext(
+                id ?: throw IllegalArgumentException("SourceSync must have an id"),
+                projectManagementId,
+                admins,
+                SourceSyncContextConfigurations(
+                    mappings.users,
+                ),
+            )
+    }
+
+    class SourceSyncContextConfigurations(
+        val usersMappings: Map<String, String?>,
+    )
+}

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepository.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepository.kt
@@ -3,6 +3,7 @@ package com.angorasix.projects.management.integrations.infrastructure.persistenc
 import com.angorasix.commons.domain.SimpleContributor
 import com.angorasix.projects.management.integrations.domain.integration.asset.IntegrationAsset
 import com.angorasix.projects.management.integrations.domain.integration.asset.IntegrationAssetSyncEvent
+import com.angorasix.projects.management.integrations.infrastructure.domain.SourceSyncContext
 import com.angorasix.projects.management.integrations.infrastructure.queryfilters.ListIntegrationAssetFilter
 import kotlinx.coroutines.flow.Flow
 
@@ -15,12 +16,14 @@ import kotlinx.coroutines.flow.Flow
 interface IntegrationAssetInfraRepository {
     fun findUsingFilter(
         filter: ListIntegrationAssetFilter,
+        sourceSyncContext: SourceSyncContext,
         requestingContributor: SimpleContributor? = null,
         allowAnonymous: Boolean = false,
     ): Flow<IntegrationAsset>
 
     suspend fun findSingleUsingFilter(
         filter: ListIntegrationAssetFilter,
+        sourceSyncContext: SourceSyncContext,
         requestingContributor: SimpleContributor? = null,
         allowAnonymous: Boolean = false,
     ): IntegrationAsset?
@@ -28,11 +31,16 @@ interface IntegrationAssetInfraRepository {
     suspend fun registerEvent(
         filter: ListIntegrationAssetFilter,
         event: IntegrationAssetSyncEvent,
+        sourceSyncContext: SourceSyncContext,
+        requestingContributor: SimpleContributor? = null,
+        allowAnonymous: Boolean = false,
     )
 
     suspend fun registerCorrespondences(
         correspondences: List<Pair<String, String>>,
-        sourceSyncId: String,
         syncingEventId: String,
+        sourceSyncContext: SourceSyncContext,
+        requestingContributor: SimpleContributor? = null,
+        allowAnonymous: Boolean = false,
     )
 }

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
@@ -60,7 +60,7 @@ class IntegrationAssetInfraRepositoryImpl(
             val query = correspondenceQuery(it.first, sourceSyncId)
             val update =
                 Update()
-                    .push("integrationStatus.events", ackEvent)
+                    .push("integrationAssetStatus.events", ackEvent)
                     .set("angoraSixData", A6AssetData.task(it.second))
             bulkOps.updateOne(query, update)
         }
@@ -105,4 +105,4 @@ private fun ListIntegrationAssetFilter.toAllByIdQuery(): Query {
     return query
 }
 
-private fun addEvent(event: IntegrationAssetSyncEvent): Update = Update().push("integrationStatus.events", event)
+private fun addEvent(event: IntegrationAssetSyncEvent): Update = Update().push("integrationAssetStatus.events", event)

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.angorasix.commons.domain.SimpleContributor
 import com.angorasix.projects.management.integrations.domain.integration.asset.A6AssetData
 import com.angorasix.projects.management.integrations.domain.integration.asset.IntegrationAsset
 import com.angorasix.projects.management.integrations.domain.integration.asset.IntegrationAssetSyncEvent
+import com.angorasix.projects.management.integrations.infrastructure.domain.SourceSyncContext
 import com.angorasix.projects.management.integrations.infrastructure.queryfilters.ListIntegrationAssetFilter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
@@ -19,29 +20,34 @@ class IntegrationAssetInfraRepositoryImpl(
 ) : IntegrationAssetInfraRepository {
     override fun findUsingFilter(
         filter: ListIntegrationAssetFilter,
+        sourceSyncContext: SourceSyncContext,
         requestingContributor: SimpleContributor?,
         allowAnonymous: Boolean,
     ): Flow<IntegrationAsset> =
         mongoOps
-            .find(filter.toQuery(requestingContributor, allowAnonymous), IntegrationAsset::class.java)
+            .find(filter.toQuery(sourceSyncContext, requestingContributor, allowAnonymous), IntegrationAsset::class.java)
             .asFlow()
 
     override suspend fun findSingleUsingFilter(
         filter: ListIntegrationAssetFilter,
+        sourceSyncContext: SourceSyncContext,
         requestingContributor: SimpleContributor?,
         allowAnonymous: Boolean,
     ): IntegrationAsset? =
         mongoOps
-            .find(filter.toQuery(requestingContributor), IntegrationAsset::class.java)
+            .find(filter.toQuery(sourceSyncContext, requestingContributor, allowAnonymous), IntegrationAsset::class.java)
             .awaitFirstOrNull()
 
     override suspend fun registerEvent(
         filter: ListIntegrationAssetFilter,
         event: IntegrationAssetSyncEvent,
+        sourceSyncContext: SourceSyncContext,
+        requestingContributor: SimpleContributor?,
+        allowAnonymous: Boolean,
     ) {
         mongoOps
             .updateMulti(
-                filter.toAllByIdQuery(),
+                filter.toAllByIdQuery(sourceSyncContext, requestingContributor, allowAnonymous),
                 addEvent(event),
                 IntegrationAsset::class.java,
             ).awaitFirstOrNull()
@@ -49,15 +55,18 @@ class IntegrationAssetInfraRepositoryImpl(
 
     override suspend fun registerCorrespondences(
         correspondences: List<Pair<String, String>>,
-        sourceSyncId: String,
         syncingEventId: String,
+        sourceSyncContext: SourceSyncContext,
+        requestingContributor: SimpleContributor?,
+        allowAnonymous: Boolean,
     ) {
         val bulkOps =
             mongoOps.bulkOps(BulkOperations.BulkMode.UNORDERED, IntegrationAsset::class.java)
         val ackEvent = IntegrationAssetSyncEvent.ack(syncingEventId)
 
         correspondences.forEach {
-            val query = correspondenceQuery(it.first, sourceSyncId)
+            val query =
+                correspondenceQuery(it.first, sourceSyncContext.sourceSyncId, sourceSyncContext, requestingContributor, allowAnonymous)
             val update =
                 Update()
                     .push("integrationAssetStatus.events", ackEvent)
@@ -71,7 +80,13 @@ class IntegrationAssetInfraRepositoryImpl(
 private fun correspondenceQuery(
     id: String,
     sourceSyncId: String,
+    sourceSyncContext: SourceSyncContext,
+    requestingContributor: SimpleContributor?,
+    allowAnonymous: Boolean = false,
 ): Query {
+    if (!allowAnonymous) {
+        sourceSyncContext.requireAdmin(requestingContributor?.contributorId)
+    }
     val query = Query()
     query.addCriteria(where("_id").`is`(id))
     query.addCriteria(where("sourceSyncId").`is`(sourceSyncId))
@@ -79,17 +94,14 @@ private fun correspondenceQuery(
 }
 
 private fun ListIntegrationAssetFilter.toQuery(
+    sourceSyncContext: SourceSyncContext,
     requestingContributor: SimpleContributor?,
     allowAnonymous: Boolean = false,
 ): Query {
     if (!allowAnonymous) {
-        requireNotNull(requestingContributor)
+        sourceSyncContext.requireAdmin(requestingContributor?.contributorId)
     }
     val query = Query()
-
-    requestingContributor?.let {
-        query.addCriteria(where("admins.contributorId").`is`(it.contributorId))
-    }
 
     ids?.let { query.addCriteria(where("_id").`in`(it as Collection<Any>)) }
     assetDataId?.let { query.addCriteria(where("sourceData.id").`in`(it as Collection<Any>)) }
@@ -99,9 +111,17 @@ private fun ListIntegrationAssetFilter.toQuery(
     return query
 }
 
-private fun ListIntegrationAssetFilter.toAllByIdQuery(): Query {
+private fun ListIntegrationAssetFilter.toAllByIdQuery(
+    sourceSyncContext: SourceSyncContext,
+    requestingContributor: SimpleContributor?,
+    allowAnonymous: Boolean = false,
+): Query {
+    if (!allowAnonymous) {
+        sourceSyncContext.requireAdmin(requestingContributor?.contributorId)
+    }
+
     val query = Query()
-    ids?.let { query.addCriteria(where("_id").`in`(it as Collection<Any>)) }
+    ids?.let { query.addCriteria(where("_id").`in`(it)) } // as Collection<Any>)) }
     return query
 }
 

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/persistence/repository/IntegrationAssetInfraRepositoryImpl.kt
@@ -94,7 +94,6 @@ private fun ListIntegrationAssetFilter.toQuery(
     ids?.let { query.addCriteria(where("_id").`in`(it as Collection<Any>)) }
     assetDataId?.let { query.addCriteria(where("sourceData.id").`in`(it as Collection<Any>)) }
     sourceSyncId?.let { query.addCriteria(where("sourceSyncId").`in`(it as Collection<Any>)) }
-    integrationId?.let { query.addCriteria(where("integrationId").`in`(it as Collection<Any>)) }
     sources?.let { query.addCriteria(where("source").`in`(it as Collection<Any>)) }
 
     return query

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/queryfilters/ListIntegrationAssetFilter.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/infrastructure/queryfilters/ListIntegrationAssetFilter.kt
@@ -14,14 +14,12 @@ data class ListIntegrationAssetFilter(
     val ids: Collection<String>? = null, // internal asset ids
     val assetDataId: Collection<String>? = null, // external asset ids
     val sourceSyncId: Collection<String>? = null,
-    val integrationId: Collection<String>? = null,
     val sources: Set<String>? = null,
 ) {
     fun toMultiValueMap(): MultiValueMap<String, String> {
         val multiMap: MultiValueMap<String, String> = LinkedMultiValueMap()
         assetDataId?.let { multiMap.add("assetDataId", assetDataId.joinToString(",")) }
         sourceSyncId?.let { multiMap.add("sourceSyncId", sourceSyncId.joinToString(",")) }
-        integrationId?.let { multiMap.add("integrationId", integrationId.joinToString(",")) }
         sources?.let { multiMap.add("sources", sources.joinToString(",")) }
         ids?.let { multiMap.add("ids", ids.joinToString(",")) }
         return multiMap

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/messaging/router/ProjectsManagementIntegrationsMessagingRouter.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/messaging/router/ProjectsManagementIntegrationsMessagingRouter.kt
@@ -16,10 +16,10 @@ class ProjectsManagementIntegrationsMessagingRouter(
     val handler: ProjectsManagementIntegrationsMessagingHandler,
 ) {
     @Bean
-    fun pendingSyncing(): (A6InfraMessageDto) -> Unit = { handler.reprocessPendingAssets(it) }
+    fun pendingSyncing(): java.util.function.Function<A6InfraMessageDto, Unit> =
+        java.util.function.Function { handler.reprocessPendingAssets(it) }
 
     @Bean
-    fun tasksSyncingCorrespondence(): (
-        A6InfraMessageDto,
-    ) -> Unit = { handler.processSyncingCorrespondence(it) }
+    fun tasksSyncingCorrespondence(): java.util.function.Function<A6InfraMessageDto, Unit> =
+        java.util.function.Function { handler.processSyncingCorrespondence(it) }
 }

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/presentation/dto/Dto.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/presentation/dto/Dto.kt
@@ -31,7 +31,6 @@ data class SourceSyncDto(
     val projectManagementId: String? = null,
     val status: SourceSyncStatusDto? = null,
     val config: SourceSyncConfigDto? = null,
-    val sourceAssets: List<IntegrationAssetDto> = emptyList(),
     val id: String? = null,
 ) : RepresentationModel<SourceSyncDto>()
 

--- a/src/main/kotlin/com/angorasix/projects/management/integrations/presentation/mappings/SourceSyncDtoMappings.kt
+++ b/src/main/kotlin/com/angorasix/projects/management/integrations/presentation/mappings/SourceSyncDtoMappings.kt
@@ -54,7 +54,6 @@ fun SourceSync.convertToDto(
         projectManagementId,
         status.convertToDto(),
         config.convertToDto(),
-        assets.map { it.convertToDto() },
         id,
     ).resolveHypermedia(
         contributor,

--- a/src/main/resources/amqp.yml
+++ b/src/main/resources/amqp.yml
@@ -44,7 +44,7 @@ spring:
           environment:
             spring:
               rabbitmq:
-                host: ${A6_MGMT_INTEGRATIONS_RABBITMQ_HO  ST:localhost}
+                host: ${A6_MGMT_INTEGRATIONS_RABBITMQ_HOST:localhost}
                 port: ${A6_MGMT_INTEGRATIONS_RABBITMQ_PORT:5672}
                 username: ${A6_MGMT_INTEGRATIONS_RABBITMQ_USER:guest}
                 password: ${A6_MGMT_INTEGRATIONS_RABBITMQ_PASSWORD:guest}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ server:
 
 logging:
   level:
-    root: ${A6_PROJECTS_MGMT_INTEGRATIONS_LOGGING_LEVEL:DEBUG}
+    root: ${A6_PROJECTS_MGMT_INTEGRATIONS_LOGGING_LEVEL:INFO}
     reactor.netty: ${A6_PROJECTS_MGMT_INTEGRATIONS_LOGGING_LEVEL_WEB:INFO}
     org.springframework.web.reactive.function.client: ${A6_PROJECTS_MGMT_INTEGRATIONS_LOGGING_LEVEL_WEB:INFO}
 


### PR DESCRIPTION
Assets sync with tasks on change (update of user mappings or fullSync)

Possible Optmizations:
- Save mappings on IntegrationAssets: allows to only send assets that where affected by a change on the mappings. Now we are sending all.